### PR TITLE
Allow for attaching events for initial rows in set

### DIFF
--- a/set.js
+++ b/set.js
@@ -107,20 +107,22 @@ function Set(doc, key, value) {
     }
   }
 
-  // add rows on nextTick so that user can bind listeners to set
-  process.nextTick(function () {
-    for(var id in doc.rows) {
-      var row = doc.get(id)
-      if (key && row.get(key) === value) {
-        add(row)
-      } else if (filter && filter(row.state)) {
-        add(row)
-      }
+  for(var id in doc.rows) {
+    var row = doc.get(id)
+    if (key && row.get(key) === value) {
+      add(row)
+    } else if (filter && filter(row.state)) {
+      add(row)
     }
-  })
+  }
 
   this.setMaxListeners(Infinity)
 
+}
+
+Set.prototype.every = function (callback) {
+  this.forEach(callback)
+  this.on("add", callback)
 }
 
 Set.prototype.asArray = function () {

--- a/test/sets.js
+++ b/test/sets.js
@@ -120,7 +120,7 @@ exports['test - create set later'] = function (t) {
   var set = doc.createSet("type", "thing")
   var states = []
 
-  set.on("add", function (row, state) {
+  set.every(function (row, state) {
     states.push(row.state)
   })
 


### PR DESCRIPTION
Add existing rows to the set later.

This ensures the user has enough time to bind events to `"add"` and `"changes"` on the set before those rows are added.

The tradeoff is that you can't synchronously check `set.toJSON()` for any valid rows until the next tick.
