### PR TITLE
Fix duplicates in crdt.Set

### DIFF
--- a/set.js
+++ b/set.js
@@ -57,6 +57,10 @@ function Set(doc, key, value) {
   }
 
   function add(row) {
+    if (rows[row.id]) {
+      return
+    }
+
     array.push(row)
     rows[row.id] = row
     set.emit('add', row)


### PR DESCRIPTION
`crdt.Set` can have duplicate rows in it if you do

``` js
doc.add({ id: "foo", type: "in-set" })
doc.add({ id: "foo", type: "in-set" })
```

Both of those additions trigger the `doc.sets.emit("type")` event
thus getting the same row in a set twice.

This patch ensures the row isn't in the set before it's added.
