### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#CRDT - Commutative Replicated Data Types
+# CRDT - Commutative Replicated Data Types
 
 a CRDT is a data type designed so that operations on it commute - give the same result
 indepent of the order in which they are applied.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
